### PR TITLE
Some refactors

### DIFF
--- a/include/CPU.h
+++ b/include/CPU.h
@@ -9,6 +9,7 @@
 #include "Global.h"
 
 //REGISTER INDEXES
+//These can be enums and use the actual bits so you can & them.
 #define A 0
 #define F 1
 #define B 2
@@ -18,12 +19,6 @@
 #define H 6
 #define L 7
 
-//FLAG bits
-#define ZERO_BIT        7
-#define SUB_BIT         6
-#define HC_BIT          5
-#define CARRY_BIT       4
-
 //FLAG bitmasks
 #define ZERO_FLAG_MASK  0x80
 #define SUB_FLAG_MASK   0x40
@@ -32,81 +27,102 @@
 
 class Z80
 {
+	//Register type
+	//Unions allow you to read and write the same region of memory in different ways
+	// Word is the full 16 bytes, Low and High will allow you to access the low and
+	//    high bytes.
+	// Could possibly do this for each and every register so you can access variables
+	//    individually such as the Flag bits of the AF register.
+	typedef union
+	{
+		struct
+		{
+			uint8_t Low;
+			uint8_t High;
+		};
+		uint16_t Word;
+	} Register16;
+
+	//FLAG bits
+	enum Flags
+	{
+		ZERO = 0x80,	// Zero Flag
+		SUB = 0x40,	// Add/Subtract
+		HALF_CARRY = 0x20,	// Half-Carry
+		CARRY = 0x10	// Carry
+	};
 public:
 
-    Z80();
-    ~Z80();
+	Z80();
+	~Z80();
 
-    uint8_t     readRegister(uint8_t reg);
-    uint16_t    readRegister16(uint8_t reg1, uint8_t reg2); //Pair two registers together and return the value (TODO: How are we storing registers??)
-    void        updateFlags(); //Update the FLAGS booleans.
-    void        writeReg(uint8_t reg, uint8_t value); //Write to a regigster
-    void        writeReg16(uint8_t reghi, uint8_t reglo, uint16_t value);
+	uint8_t     readRegister(uint8_t reg);
+	uint16_t    readRegister16(uint8_t reg1, uint8_t reg2);
+	void        updateFlags(); //Update the FLAGS booleans.
+	void        writeReg(uint8_t reg, uint8_t value); //Write to a regigster
+	void        writeReg16(uint8_t reghi, uint8_t reglo, uint16_t value);
 
-    void        setFlagBit(uint8_t bit);
-    void        unsetFlagBit(uint8_t bit);
+	void        setFlagBit(Flags flags);
+	void        unsetFlagBit(Flags flags);
 
-    //CPU functions
-    void        incrementStackPointer();
-    void        decrementStackPointer();
-    uint16_t    getStackPointer();
-    void        incrementProgramCounter();
-    void        decrementProgramCounter();
-    void        setProgramCounter(uint16_t value);
-    uint16_t    getProgramCounter();
-    void        resetCPU();
+	//CPU functions
+	void        incrementStackPointer();
+	void        decrementStackPointer();
+	uint16_t    getStackPointer();
+	void        incrementProgramCounter();
+	void        decrementProgramCounter();
+	void        setProgramCounter(uint16_t value);
+	uint16_t    getProgramCounter();
+	void        resetCPU();
 
-    void        memWrite(uint16_t addr, uint8_t value);
-    uint8_t     memRead(uint16_t addr);
-    void        memWrite16(uint16_t addr, uint16_t value);
-    uint16_t    memRead16(uint16_t addr);
+	void        memWrite(uint16_t addr, uint8_t value);
+	uint8_t     memRead(uint16_t addr);
+	void        memWrite16(uint16_t addr, uint16_t value);
+	uint16_t    memRead16(uint16_t addr);
 
+	//Our main CPU function
+	uint8_t tick();
 
-    //Our main CPU function
-    uint8_t cycle();
-
-
-    void logEverything();
+	void logEverything();
 
 private:
-    /**
-        Our 8, 8-bit CPU Registers; A, F(lags), B, C, D, E, H, L
+	/**
+		Our 8, 8-bit CPU Registers; A, F(lags), B, C, D, E, H, L
 
-        These registers can be paired to create a 16-bit register combo
-    **/
-    uint8_t regs[8];
+		These registers can be paired to create a 16-bit register combo
+		**/
+	Register16 AF, BC, DE, HL;
 
-    /**
-        CPU program counter. Stores current instruction to be performed in memory
+	/**
+		CPU program counter. Stores current instruction to be performed in memory
 
-        When the GameBoy is switched on, the Program Counter is intialised to 0x100, and the
-        instruction found at this location is executed
-    **/
-    uint16_t pc;
+		When the GameBoy is switched on, the Program Counter is intialised to 0x100, and the
+		instruction found at this location is executed
+		**/
+	Register16 PC;
 
-    /**
-        CPU stack pointer. Stores current location in our stack.
+	/**
+		CPU stack pointer. Stores current location in our stack.
 
-        When the GameBoy is switched on, the Stack Pointer is initialised to 0xFFFE.
-    **/
-    uint16_t sp;
+		When the GameBoy is switched on, the Stack Pointer is initialised to 0xFFFE.
+		**/
+	Register16 SP;
 
-    /**
-        Our GameBoy memory! It can contains a maximum of 65535 (0xFFFF in hex) 8-bit values. It is mapped as follows:
+	/**
+		Our GameBoy memory! It can contains a maximum of 65535 (0xFFFF in hex) 8-bit values. It is mapped as follows:
 
+		**/
+	// Todo: Gameboy memory is "paged" or "banked" so different chunks may be -armed- at different moments of time.
+	uint8_t ram[0xFFFF];
 
-    **/
-    uint8_t ram[0xFFFF];
+	/**
+		Our FLAG Booleans. These are used to check what
+		**/
 
-    /**
-        Our FLAG Booleans. These are used to check what
-    **/
-
-    bool zero = false; //Result of math operation is zero
-    bool sub = false; //Subtraction was performed last math instruction
-    bool hc = false; //Carry occurred from lower nibble in last math operation
-    bool carry = false; //Carry occurred last math operation, or REG A is smaller than value when CP instruction is executed
+	bool zero = false; //Result of math operation is zero
+	bool sub = false; //Subtraction was performed last math instruction
+	bool hc = false; //Carry occurred from lower nibble in last math operation
+	bool carry = false; //Carry occurred last math operation, or REG A is smaller than value when CP instruction is executed
 };
-
 
 #endif // CPU_H_INCLUDED

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -1,559 +1,542 @@
 #include "../include/CPU.h"
 
 /**
-    Class Constructor
-**/
+	Class Constructor
+	**/
 Z80::Z80()
 {
-    resetCPU(); //Reset, yo!
+	resetCPU(); //Reset, yo!
 }
 
 /**
-    Class Deconstructor
-**/
+	Class Deconstructor
+	**/
 Z80::~Z80()
 {
-
 }
 
 /**
-    Our CPU's cycle function! It executes the current instruction according the address the program counter is
-    pointing at and returns the number of cycles each instruction takes to execute
-**/
-uint8_t Z80::cycle()
+	Our CPU's cycle function! It executes the current instruction according the address the program counter is
+	pointing at and returns the number of cycles each instruction takes to execute
+	**/
+uint8_t Z80::tick()
 {
-    uint8_t opcode = ram[pc]; //FETCH!
-
-    //DECODE!
-    switch(opcode)
-    {
-    case 0x00: //NOP
-        {
-            ++pc;
-            return 4; //4 Cycles required
-            break;
-        }
-    case 0x01: //16-bit load to BC
-        {
-            writeReg16(B, C, memRead16(pc++));
-
-            pc += 3;
-            return 12;
-            break;
-        }
-    case 0x02: //Store A into address pointed to by BC
-        {
-            memWrite(readRegister16(B, C), readRegister(A));
-
-            ++pc;
-            return 8;
-            break;
-        }
-    case 0x03: //INC BC
-        {
-            uint16_t regpair = readRegister16(B, C);
-            regpair++;
-            writeReg16(B, C, regpair);
-
-            ++pc;
-            return 4;
-            break;
-        }
-    case 0x04: //INC B
-        {
-            uint8_t b = readRegister(B);
-            ++b;
-
-            unsetFlagBit(SUB_BIT);
-
-            if(!(b & 0xFF)) //Is our answer zero??
-                setFlagBit(ZERO_BIT);
-
-            if(b > 0xF)
-                setFlagBit(HC_BIT);
-
-            ++pc;
-            return 4;
-            break;
-        }
-    case 0x05: //DEC B
-        {
-            uint8_t b = readRegister(B);
-            --b;
-
-            if(!(b & 0xFF)) //Is our answer zero??
-                setFlagBit(ZERO_BIT);
-
-            if(b > (b & 0xF))
-                setFlagBit(HC_BIT);
-
-            setFlagBit(SUB_BIT); //We performed a subtraction! Set sub bit
-            writeReg(B, b);
-
-            ++pc;
-            return 4;
-            break;
-        }
-    case 0x06: //Load immediate 8-bit value into B
-        {
-            writeReg(B, getProgramCounter() + 1);
-
-            pc += 2;
-            return 8;
-            break;
-        }
-    case 0x07: //Rotate A Left Through Carry...
-        {
-            uint8_t a = readRegister(A);
-            uint8_t bit7 = a & 0x80;
-
-            unsetFlagBit(ZERO_BIT);
-            unsetFlagBit(SUB_BIT);
-            unsetFlagBit(HC_BIT);
-
-            if(bit7)
-                setFlagBit(CARRY_BIT);
-
-            a <<= 1; //Perform the shift
-            a |= bit7 >> 7;
-
-            if(!(a & 0xFF)) //Do a zero check after the shift
-                setFlagBit(ZERO_BIT);
-
-            writeReg(A, a); //Write the register back to the array
-
-            return 4;
-            break;
-        }
-    case 0x08: //Load SP into 16-bit immediate address
-        {
-            memWrite16(sp,  memRead16(pc + 1));
-
-            pc += 3;
-            return 20;
-            break;
-        }
-
-    case 0x09: //ADD HL, BC
-        {
-            uint16_t hl = readRegister16(H, L);
-            uint16_t bc = readRegister16(B, C);
-
-            unsetFlagBit(SUB_BIT);
-
-            if((hl + bc) > 0xFF)
-                setFlagBit(CARRY_BIT);
-
-            if((hl & 0xF) + (bc & 0xF) > 0xF);
-                setFlagBit(HC_BIT);
-
-            writeReg16(H, L, (hl + bc));
-
-            incrementProgramCounter();
-
-            return 8;
-            break;
-        }
-    case 0x0A: //Load value at BC to register A
-        {
-            uint16_t addr = readRegister16(B, C);
-            writeReg(A, memRead(addr));
-
-            ++pc;
-            return 8;
-            break;
-        }
-    case 0x0B: //DEC BC
-        {
-            uint16_t bc = readRegister16(B, C);
-            --bc;
-
-            writeReg16(B, C, bc);
-
-            ++pc;
-            return 8;
-            break;
-        }
-    case 0x0C: //Increment C
-        {
-            uint8_t c = readRegister(C);
-            ++c;
-
-            unsetFlagBit(SUB_BIT);
-
-            if(!(c & 0xFF))
-                setFlagBit(ZERO_BIT);
-
-            if(c > 0xF)
-                setFlagBit(HC_BIT);
-
-            ++pc;
-            return 4;
-            break;
-        }
-    case 0x0D: //Decrement C
-        {
-            uint8_t c = readRegister(C);
-            --c;
-
-            setFlagBit(SUB_BIT); //We performed a subtraction
-
-            if(!(c & 0xFF))
-                setFlagBit(ZERO_BIT);
-
-            if(c > 0xF)
-                setFlagBit(HC_BIT);
-
-            ++pc;
-            return 4;
-            break;
-        }
-    case 0x0E: //Load immediate 8-bit value into C
-        {
-            writeReg(C, pc + 1);
-
-            pc += 2;
-            return 8;
-            break;
-        }
-    case 0x0F: //Rotate A right through carry
-        {
-            uint8_t a = readRegister(A);
-            uint8_t bit0 = a & 0x01;
-
-            unsetFlagBit(ZERO_BIT);
-            unsetFlagBit(SUB_BIT);
-            unsetFlagBit(HC_BIT);
-
-            if(bit0) //If bit0 == 1, set the carry bit to 1 as well
-                setFlagBit(CARRY_BIT);
-
-            a >>= 1; //Perform the shift
-            a |= bit0 << 7;
-
-            if(!(a & 0xFF)) //Do a zero check after the shift
-                setFlagBit(ZERO_BIT);
-
-            writeReg(A, a);
-
-            return 4;
-            break;
-        }
-    case 0x10:
-    {
-        //TODO: How to interpret this opcode
-        pc += 2;
-        return 4;
-        break;
-    }
-    case 0x11: //Load immediate 16-bit value into DE
-        {
-            writeReg16(D, E, memRead16(pc++));
-
-            pc += 3;
-            return 12;
-            break;
-        }
-    case 0x12: //Load A into address pointed to by DE
-        {
-            uint16_t addr = readRegister16(D, E);
-            memWrite(addr, readRegister(A));
-
-            ++pc;
-            return 8;
-            break;
-        }
-    case 0x13:
-        {
-           uint16_t de = readRegister16(D, E);
-           ++de;
-
-           writeReg16(D, E, de);
-
-           ++pc;
-           return 8;
-           break;
-        }
-    case 0x14: //Increment D
-        {
-            uint8_t d = readRegister(D);
-            ++d;
-
-            unsetFlagBit(SUB_BIT);
-
-            if(!(d & 0xFF))
-                setFlagBit(ZERO_BIT);
-
-            if(d > 0xF)
-                setFlagBit(HC_BIT);
-
-            ++pc;
-            return 4;
-            break;
-        }
-    case 0x15: //Decrement D
-        {
-            uint8_t d = readRegister(D);
-            --d;
-
-            setFlagBit(SUB_BIT);
-
-            if(!(d & 0xFF))
-                setFlagBit(ZERO_BIT);
-
-            if(d > 0xF)
-                setFlagBit(HC_BIT);
-
-            ++pc;
-            return 4;
-            break;
-        }
-    case 0x16: //Load immediate 8-bit value into D
-        {
-            writeReg(D, pc++);
-
-            pc += 2;
-            return 8;
-            break;
-        }
-    case 0x17: //Rotate A left once. Bit 7 to carry flag and carry bit to bit 0 of A
-        {
-            uint8_t a = readRegister(A);
-            uint8_t bit7 = a & 0x80;
-
-            unsetFlagBit(ZERO_BIT);
-            unsetFlagBit(SUB_BIT);
-            unsetFlagBit(HC_BIT);
-
-            if(bit7)
-                setFlagBit(CARRY_BIT);
-
-            uint8_t cbit = readRegister(F) & CARRY_FLAG_MASK;
-
-            a <<= 1; //Perform the shift
-            a |= cbit >> 4;
-
-            if(!(a & 0xFF)) //Do a zero check after the shift
-                setFlagBit(ZERO_BIT);
-
-            writeReg(A, a); //Write the register back to the array
-
-            ++pc;
-            return 4;
-            break;
-        }
-    case 0x18: //Add 8-bit immediate value to PC and jump to that address
-        {
-            uint16_t addr = pc + (++pc)
-
-            pc = addr;
-            return 8;
-            break;
-        }
-    case 0x19: //Add DE to HL
-        {
-            uint16_t de = readRegister16(D, E);
-            uint16_t hl = readRegister16(H, L);
-
-            if((hl + de) > 0xFF)
-                setFlagBit(CARRY_BIT);
-
-            if((hl & 0xF) + (de & 0xF) > 0xF);
-                setFlagBit(HC_BIT);
-
-            writeReg16(H, L, (hl + de));
-
-            ++pc;
-            return 8;
-            break;
-        }
-    case 0x1A: //Load value at Address in DE into reg A
-        {
-            uint8_t a = readRegister(A);
-            uint16_t addr = readRegister16(D, E);
-
-            a = memRead16(addr); //Read address in DE
-
-            writeReg(A, a);
-            ++pc;
-            return 8;
-            breakl
-        }
-    case 0x1B: //Decrement DE
-        {
-            uint16_t de = readRegister16(D, E);
-
-            --de;
-
-            ++pc;
-            return 8;
-            break;
-        }
-    case 0x1C:
-        {
-            uint8_t e = readRegister(E);
-
-            ++e;
-
-            unsetFlagBit(SUB_BIT);
-
-            if(!(e & 0xFF))
-                setFlagBit(ZERO_BIT);
-
-            if(e > 0xF)
-                setFlagBit(HC_BIT);
-        }
-    default:
-        {
-            std::cerr << "INVALID OPCODE: " << ram[pc];
-            exit(INVALID_OPCODE_EXIT);
-            break;
-        }
-    }
-    return 4;
+	uint8_t opcode = ram[pc]; //FETCH!
+
+	//DECODE!
+	switch( opcode )
+	{
+	case 0x00: //NOP
+	{
+		PC.Word++;
+		return 4; //4 Cycles required
+		break;
+	}
+	case 0x01: //16-bit load to BC
+	{
+		writeReg16(B, C, memRead16(pc++));
+
+		PC.Word += 3;
+		return 12;
+		break;
+	}
+	case 0x02: //Store A into address pointed to by BC
+	{
+		memWrite(BC.Word, readRegister(A));
+
+		PC.Word++;
+		return 8;
+		break;
+	}
+	case 0x03: //INC BC
+	{
+		BC.Word++;
+		PC.Word++;
+		return 4;
+		break;
+	}
+	case 0x04: //INC B
+	{
+		BC.Low++;
+
+		unsetFlagBit(SUB);
+
+		if( !(b & 0xFF) ) //Is our answer zero??
+			setFlagBit(ZERO);
+
+		if( b > 0xF )
+			setFlagBit(HALF_CARRY);
+
+		PC.Word++;
+		return 4;
+		break;
+	}
+	case 0x05: //DEC B
+	{
+		BC.Low--;
+
+		if( !(BC.Low & 0xFF) ) //Is our answer zero??
+			setFlagBit(ZERO);
+
+		if( BC.Low > (BC.Low & 0xF) )
+			setFlagBit(HALF_CARRY);
+
+		setFlagBit(SUB); //We performed a subtraction! Set sub bit
+
+		PC.Word++;
+		return 4;
+		break;
+	}
+	case 0x06: //Load immediate 8-bit value into B
+	{
+		writeReg(BC.Low, getProgramCounter() + 1);
+
+		pc += 2;
+		return 8;
+		break;
+	}
+	case 0x07: //Rotate A Left Through Carry...
+	{
+		uint8_t bit7 = AF.Low & 0x80;
+
+		unsetFlagBit(ZERO);
+		unsetFlagBit(SUB);
+		unsetFlagBit(HALF_CARRY);
+
+		if( bit7 )
+			setFlagBit(CARRY);
+
+		a <<= 1; //Perform the shift
+		a |= bit7 >> 7;
+
+		if( !(a & 0xFF) ) //Do a zero check after the shift
+			setFlagBit(ZERO);
+
+		writeReg(A, a); //Write the register back to the array
+
+		return 4;
+		break;
+	}
+	case 0x08: //Load SP into 16-bit immediate address
+	{
+		memWrite16(SP.Word, memRead16(pc + 1));
+
+		pc += 3;
+		return 20;
+		break;
+	}
+
+	case 0x09: //ADD HL, BC
+	{
+		unsetFlagBit(SUB);
+
+		if( (HL.Word + BC.Word) > 0xFF )
+			setFlagBit(CARRY);
+
+		if( (HL.Word & 0xF) + (BC.Word & 0xF) > 0xF );
+		setFlagBit(HALF_CARRY);
+
+		HL.Word = HL.Word + BC.Word;
+
+		incrementProgramCounter();
+
+		return 8;
+		break;
+	}
+	case 0x0A: //Load value at BC to register A
+	{
+		AF.Low = memRead(BC.Word);
+
+		PC.Word++;
+		return 8;
+		break;
+	}
+	case 0x0B: //DEC BC
+	{
+		BC.Word--;
+
+		PC.Word++;
+		return 8;
+		break;
+	}
+	case 0x0C: //Increment C
+	{
+		BC.High++;
+
+		unsetFlagBit(SUB);
+
+		if( !(BC.High++ & 0xFF) )
+			setFlagBit(ZERO);
+
+		if( BC.High++ > 0xF )
+			setFlagBit(HALF_CARRY);
+
+		PC.Word++;
+		return 4;
+		break;
+	}
+	case 0x0D: //Decrement C
+	{
+		BC.High--;
+
+		setFlagBit(SUB); //We performed a subtraction
+
+		if( !(BC.High & 0xFF) )
+			setFlagBit(ZERO);
+
+		if( BC.High > 0xF )
+			setFlagBit(HALF_CARRY);
+
+		PC.Word++;
+		return 4;
+		break;
+	}
+	case 0x0E: //Load immediate 8-bit value into C
+	{
+		writeReg(C, pc + 1);
+
+		pc += 2;
+		return 8;
+		break;
+	}
+	case 0x0F: //Rotate A right through carry
+	{
+		uint8_t a = readRegister(A);
+		uint8_t bit0 = a & 0x01;
+
+		unsetFlagBit(ZERO);
+		unsetFlagBit(SUB);
+		unsetFlagBit(HALF_CARRY);
+
+		if( bit0 ) //If bit0 == 1, set the carry bit to 1 as well
+			setFlagBit(CARRY);
+
+		a >>= 1; //Perform the shift
+		a |= bit0 << 7;
+
+		if( !(a & 0xFF) ) //Do a zero check after the shift
+			setFlagBit(ZERO);
+
+		writeReg(A, a);
+
+		return 4;
+		break;
+	}
+	case 0x10:
+	{
+		//TODO: How to interpret this opcode
+		pc += 2;
+		return 4;
+		break;
+	}
+	case 0x11: //Load immediate 16-bit value into DE
+	{
+		writeReg16(D, E, memRead16(pc++));
+
+		pc += 3;
+		return 12;
+		break;
+	}
+	case 0x12: //Load A into address pointed to by DE
+	{
+		uint16_t addr = readRegister16(D, E);
+		memWrite(addr, readRegister(A));
+
+		PC.Word++;
+		return 8;
+		break;
+	}
+	case 0x13:
+	{
+		uint16_t de = readRegister16(D, E);
+		++de;
+
+		writeReg16(D, E, de);
+
+		PC.Word++;
+		return 8;
+		break;
+	}
+	case 0x14: //Increment D
+	{
+		uint8_t d = readRegister(D);
+		++d;
+
+		unsetFlagBit(SUB);
+
+		if( !(d & 0xFF) )
+			setFlagBit(ZERO);
+
+		if( d > 0xF )
+			setFlagBit(HALF_CARRY);
+
+		PC.Word++;
+		return 4;
+		break;
+	}
+	case 0x15: //Decrement D
+	{
+		uint8_t d = readRegister(D);
+		--d;
+
+		setFlagBit(SUB);
+
+		if( !(d & 0xFF) )
+			setFlagBit(ZERO);
+
+		if( d > 0xF )
+			setFlagBit(HALF_CARRY);
+
+		PC.Word++;
+		return 4;
+		break;
+	}
+	case 0x16: //Load immediate 8-bit value into D
+	{
+		writeReg(D, pc++);
+
+		pc += 2;
+		return 8;
+		break;
+	}
+	case 0x17: //Rotate A left once. Bit 7 to carry flag and carry bit to bit 0 of A
+	{
+		uint8_t a = readRegister(A);
+		uint8_t bit7 = a & 0x80;
+
+		unsetFlagBit(ZERO);
+		unsetFlagBit(SUB);
+		unsetFlagBit(HALF_CARRY);
+
+		if( bit7 )
+			setFlagBit(CARRY);
+
+		uint8_t cbit = readRegister(F) & CARRY_FLAG_MASK;
+
+		a <<= 1; //Perform the shift
+		a |= cbit >> 4;
+
+		if( !(a & 0xFF) ) //Do a zero check after the shift
+			setFlagBit(ZERO);
+
+		writeReg(A, a); //Write the register back to the array
+
+		PC.Word++;
+		return 4;
+		break;
+	}
+	case 0x18: //Add 8-bit immediate value to PC and jump to that address
+	{
+		uint16_t addr = pc + (PC.Word++)
+
+			pc = addr;
+		return 8;
+		break;
+	}
+	case 0x19: //Add DE to HL
+	{
+		uint16_t de = readRegister16(D, E);
+		uint16_t hl = readRegister16(H, L);
+
+		if( (hl + de) > 0xFF )
+			setFlagBit(CARRY);
+
+		if( (hl & 0xF) + (de & 0xF) > 0xF );
+		setFlagBit(HALF_CARRY);
+
+		writeReg16(H, L, (hl + de));
+
+		PC.Word++;
+		return 8;
+		break;
+	}
+	case 0x1A: //Load value at Address in DE into reg A
+	{
+		uint8_t a = readRegister(A);
+		uint16_t addr = readRegister16(D, E);
+
+		a = memRead16(addr); //Read address in DE
+
+		writeReg(A, a);
+		PC.Word++;
+		return 8;
+		breakl
+	}
+	case 0x1B: //Decrement DE
+	{
+		uint16_t de = readRegister16(D, E);
+
+		--de;
+
+		PC.Word++;
+		return 8;
+		break;
+	}
+	case 0x1C:
+	{
+		uint8_t e = readRegister(E);
+
+		++e;
+
+		unsetFlagBit(SUB);
+
+		if( !(e & 0xFF) )
+			setFlagBit(ZERO);
+
+		if( e > 0xF )
+			setFlagBit(HALF_CARRY);
+	}
+	default:
+	{
+		std::cerr << "INVALID OPCODE: " << ram[pc];
+		exit(INVALID_OPCODE_EXIT);
+		break;
+	}
+	}
+	return 4;
 }
 
 /**
-    Reset the CPU to it's initial initialisation state (outline in the CPU manual, pg.64)
-**/
+	Reset the CPU to it's initial initialisation state (outline in the CPU manual, pg.64)
+	**/
 void Z80::resetCPU()
 {
-    //Reset our PC and SP to their defaults
-    pc = 0x0100;
-    sp = 0xFFFE;
-    memset(ram, 0x00, 0xFFFF); //Zero our RAM
+	//Reset our PC and SP to their defaults
+	pc = 0x0100;
+	sp = 0xFFFE;
+	memset(ram, 0x00, 0xFFFF); //Zero our RAM
 }
 
 void Z80::incrementProgramCounter()
 {
-    ++pc;
+	PC.Word++;
 }
 
 void Z80::decrementProgramCounter()
 {
-    --pc;
+	PC.Word++;
 }
 
 void Z80::setProgramCounter(uint16_t value)
 {
-    pc = value;
+	pc.Word = value;
 }
 
 uint16_t Z80::getProgramCounter()
 {
-    return pc & 0xFFFF;
+	return pc.Word;
 }
 
 void Z80::incrementStackPointer()
 {
-    ++sp;
+	sp.Word++;
 }
 
 void Z80::decrementStackPointer()
 {
-    --sp;
+	sp.Word--
 }
 
 uint16_t Z80::getStackPointer()
 {
-    return sp & 0xFFFF;
+	return sp.Word & 0xFFFF;
 }
 
 /**
-    Write an 8-bit value to GameBoy memory
-**/
+	Write an 8-bit value to GameBoy memory
+	**/
 void Z80::memWrite(uint16_t addr, uint8_t value)
 {
-    ram[addr] = value & 0xFF;
+	ram[addr] = value & 0xFF;
 }
 
 /**
-    Read an 8-bit value from memory and align it 16-bit
-**/
+	Read an 8-bit value from memory and align it 16-bit
+	**/
 uint8_t Z80::memRead(uint16_t addr)
 {
-    uint16_t ret = ram[addr] & 0xFF; //If we're using an 8-bit load, why the fuck 0xFFFF????
+	uint16_t ret = ram[addr] & 0xFF; //If we're using an 8-bit load, why the fuck 0xFFFF????
 
-    return ret;
+	return ret;
 }
 
 //The GameBoy is Little-Endian, right???
 void Z80::memWrite16(uint16_t addr, uint16_t value)
 {
-    uint8_t val_hi = value & 0xFF;
-    uint8_t val_lo = (value >> 8) & 0xFF;
+	uint8_t val_hi = value & 0xFF;
+	uint8_t val_lo = (value >> 8) & 0xFF;
 
-    memWrite(addr, val_hi);
-    memWrite(addr, val_lo);
+	memWrite(addr, val_hi);
+	memWrite(addr, val_lo);
 }
 
 uint16_t Z80::memRead16(uint16_t addr)
 {
-    uint16_t ret = ((ram[addr] & 0xFF) << 8) + (ram[addr + 1] & 0xFF);
+	uint16_t ret = ((ram[addr] & 0xFF) << 8) + (ram[addr + 1] & 0xFF);
 
-    return ret;
+	return ret;
 }
 
 //Read a register pair
 uint16_t Z80::readRegister16(uint8_t reg1, uint8_t reg2)
 {
-    uint16_t ret = (reg1 << 8) | reg2;
+	uint16_t ret = (reg1 << 8) | reg2;
 
-    return ret;
+	return ret;
 }
 
 //Thank you, /g/...
 void Z80::updateFlags()
 {
-    //Update our flags booleans by determining what bits are switched on in the FLAGS register.
-    zero = (bool)(regs[F] & ZERO_FLAG_MASK);
-    sub = (bool)(regs[F] & SUB_FLAG_MASK);
-    hc = (bool)(regs[F] & HC_FLAG_MASK);
-    carry = (bool)(regs[F] & CARRY_FLAG_MASK);
+	//Update our flags booleans by determining what bits are switched on in the FLAGS register.
+	zero = (bool)(regs[F] & ZERO_FLAG_MASK);
+	sub = (bool)(regs[F] & SUB_FLAG_MASK);
+	hc = (bool)(regs[F] & HC_FLAG_MASK);
+	carry = (bool)(regs[F] & CARRY_FLAG_MASK);
 }
 
 uint8_t Z80::readRegister(uint8_t reg)
 {
-    return regs[reg];
+	return regs[reg];
 }
 
 //Write "value" to register "reg"
 void Z80::writeReg(uint8_t reg, uint8_t value)
 {
-    regs[reg] = value;
+	regs[reg] = value;
 }
 
 //Write a 16 bit value to a register pair
 void Z80::writeReg16(uint8_t reghi, uint8_t reglo, uint16_t value)
 {
-    //Seperate the value into it's low and high byte
-    //GameBoy is apparently Little Endian, so store the LSB into the hi register in the pair
-    regs[reghi] = value & 0xFF;
-    regs[reglo] = value >> 8;
+	//Seperate the value into it's low and high byte
+	//GameBoy is apparently Little Endian, so store the LSB into the hi register in the pair
+	regs[reghi] = value & 0xFF;
+	regs[reglo] = value >> 8;
 }
 
 //Set bits in the FLAG register
 void Z80::setFlagBit(uint8_t bit)
 {
-    uint8_t flags = readRegister(F);
-    flags |= 1 << bit;
-    writeReg(F, flags);
-    updateFlags();
+	uint8_t flags = readRegister(F);
+	flags |= 1 << bit;
+	writeReg(F, flags);
+	updateFlags();
 }
 
 //Unset bit in the FLAG register
 void Z80::unsetFlagBit(uint8_t bit)
 {
-    uint8_t flags = readRegister(F);
-    flags &= ~(1 << bit);
-    writeReg(F, flags);
-    updateFlags();
+	uint8_t flags = readRegister(F);
+	flags &= ~(1 << bit);
+	writeReg(F, flags);
+	updateFlags();
 }
 
 //Dump EVERYTHING from the CPU to a nice table in console :)
 void Z80::logEverything()
 {
-    std::cout << "A    |" << "F    |" << "B    |" << "C    |" << "D    |" << "E    |" << "H    |" << "L    |" << "SP    |" << "PC" << std::endl;
-    //cout doesn't like uint8_t (prints out the char value, I can't be stuffed casting...), so we're using printf!
-    printf("%x   %x    %x    %x    %x    %x    %x    %x    %x    %x", regs[A], regs[F], regs[B], regs[C], regs[D], regs[E], regs[H], regs[L], this->getStackPointer(), this->getProgramCounter());
+	std::cout << "A    |" << "F    |" << "B    |" << "C    |" << "D    |" << "E    |" << "H    |" << "L    |" << "SP    |" << "PC" << std::endl;
+	//cout doesn't like uint8_t (prints out the char value, I can't be stuffed casting...), so we're using printf!
+	printf("%x   %x    %x    %x    %x    %x    %x    %x    %x    %x", regs[A], regs[F], regs[B], regs[C], regs[D], regs[E], regs[H], regs[L], this->getStackPointer(), this->getProgramCounter());
 }


### PR DESCRIPTION
I edited and changed a lot of code(untested) regarding the general structure of this. This project seems to be using codeblocks while I use visual studio so I had to just edit the files manually.
Before diving into the opcode case switch some design-wise changes can be made. That grind-work can be deferred to later once everything is in place such as rom reading and having concise code.

Unions can be used to make the handling of registers easier.
Unions let you pick at the same region of memory in different ways so a 16 bit register can be accessed by its individual bytes.

```
    typedef union
    {
        struct
        {
            uint8_t Low;
            uint8_t High;
        };
        uint16_t Word;
    } Register16;
```

This "register16" object would be 16 bits(2 bytes) total and can be accessed using `.word` or `.Low`/`.High` to access the individual bytes.
The `define` chunks can be replaced with enums with can contain your constant variables. Ex:

```
//FLAG bits
enum Flags
{
    ZERO = 0x80,    // Zero Flag
    SUB = 0x40, // Add/Subtract
    HALF_CARRY = 0x20,  // Half-Carry
    CARRY = 0x10    // Carry
};
```

Functions that don't actually modify their class's variables can be marked with `const`.

```
void        memWrite(uint16_t addr, uint8_t value);
uint8_t     memRead(uint16_t addr);
```

can be made into

```
void        memWrite(uint16_t addr, uint8_t value);
uint8_t     memRead(uint16_t addr) const;
```

Also rather than making local copies of variables and then modifying them you can just access the variables directly since these variables are a part of their class.
Bitfields can be used to restrict certain types to individual bits.
A bool can be represented using an int or a short or a char

```
struct Flags
{
    bool zero : 1;
    bool sub : 1;
    bool hc : 1;
    bool carry : 1;
    char Pad : 4;//Fills up the last 4 unused bits
}
```

The total size for "Flags" struct would be 1 byte. Each of those bool elements would take up those individual bytes. If I wanted to I could write an "AF" register using a union and have this struct used as the Upper bytes to make handling flags easier.
A lot of these getters and setter functions are only used internally and could be in-lined to the array accesses they are doing.
memWrite and memRead would need functions though due to the additional logic that needs to be carried out when writing and reading to registers or memory banks.
If it needs additional logic, it merits the use of a function. If the function is just containing an array accessor then just use the array accessor.
Same goes to the "increment stack pointer" functions and such. 
