### PR TITLE
MBC/ROM Header improvements.

### DIFF
--- a/Gameboy.cbp
+++ b/Gameboy.cbp
@@ -37,6 +37,7 @@
 		<Unit filename="include/Cartridge.h" />
 		<Unit filename="include/Global.h" />
 		<Unit filename="include/MMU.h" />
+		<Unit filename="include/ROMHeader.h" />
 		<Unit filename="src/CPU.cpp" />
 		<Unit filename="src/Cartridge.cpp" />
 		<Unit filename="src/MMU.cpp" />

--- a/Gameboy.depend
+++ b/Gameboy.depend
@@ -50,3 +50,40 @@
 	<fstream>
 	<iostream>
 
+1421505459 source:/home/darren/projects/ZGB/src/Cartridge.cpp
+	"../include/Cartridge.h"
+
+1421505113 /home/darren/projects/ZGB/include/Cartridge.h
+	<fstream>
+	<iostream>
+	<cstring>
+	"ROMHeader.h"
+
+1421498412 source:/home/darren/projects/ZGB/src/CPU.cpp
+	"../include/CPU.h"
+
+1421498412 /home/darren/projects/ZGB/include/CPU.h
+	<iostream>
+	<cstring>
+	<stdint.h>
+	<stdio.h>
+	"MMU.h"
+	"Global.h"
+
+1421498412 /home/darren/projects/ZGB/include/MMU.h
+	<stdint.h>
+
+1421498412 /home/darren/projects/ZGB/include/Global.h
+	<cstdlib>
+
+1421506565 source:/home/darren/projects/ZGB/src/main.cpp
+	<iostream>
+	<stdio.h>
+	"../include/CPU.h"
+	"../include/Cartridge.h"
+
+1421498412 source:/home/darren/projects/ZGB/src/MMU.cpp
+	"../include/MMU.h"
+
+1421501513 /home/darren/projects/ZGB/include/ROMHeader.h
+

--- a/include/Cartridge.h
+++ b/include/Cartridge.h
@@ -3,6 +3,7 @@
 
 #include <fstream>
 #include <iostream>
+#include "ROMHeader.h"
 
 class Cartridge
 {
@@ -19,12 +20,7 @@ public:
 
 private:
     bool romLoaded = false;
-
-    uint8_t m_MBCType = 0; //What MBC chip does the cart have?      @0x0147
-    uint8_t m_ROMSize = 0; //What size is our ROM?                  @0x0148
-    uint8_t m_RAMSize = 0; //How many ram Banks do we have?         @0x0149
-    uint8_t m_region  = 0; //0 = Japanese; 1 = Non-Japanese         @0x014A
-
+    s_ROMHeaderInfo ROMHeaderInfo;
     uint8_t rom0[0x8000]; //The actual ROM (32kB large, fixed ROM, no MBC :( )
 };
 

--- a/include/Cartridge.h
+++ b/include/Cartridge.h
@@ -3,6 +3,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <cstring>
 #include "ROMHeader.h"
 
 class Cartridge
@@ -21,7 +22,7 @@ public:
 private:
     bool romLoaded = false;
     s_ROMHeaderInfo ROMHeaderInfo;
-    uint8_t rom0[0x8000]; //The actual ROM (32kB large, fixed ROM, no MBC :( )
+    uint8_t *rom0; //Will be dynamically allocated when we read the ROM into memory.
 };
 
 

--- a/include/ROMHeader.h
+++ b/include/ROMHeader.h
@@ -1,0 +1,58 @@
+#ifndef ROMHEADER_H
+#define ROMHEADER_H
+
+struct s_ROMHeaderInfo {
+    uint8_t MBCType; //What MBC chip does the cart have?      @0x0147
+    uint8_t ROMSize; //What size is our ROM?                  @0x0148
+    uint8_t RAMSize; //How many ram Banks do we have?         @0x0149
+    uint8_t region; //0 = Japanese; 1 = Non-Japanese         @0x014A
+};
+
+#define MBC_ROM             0x00
+#define MBC_1               0x01
+#define MBC_1_RAM           0x02
+#define MBC_1_RAM_BAT       0x03
+#define MBC_2               0x05
+#define MBC_2_BAT           0x06
+#define MBC_ROM_RAM         0x08
+#define MBC_ROM_RAM_BAT     0x09
+#define MBC_MMM_01          0x0B
+#define MBC_MMM_01_RAM      0x0C
+#define MBC_MMM_01_RAM_BAT  0x0D
+#define MBC_3_TIMER_BAT     0x0F
+#define MBC_3_TIMER_RAM_BAT 0x10
+#define MBC_3               0x11
+#define MBC_3_RAM           0x12
+#define MBC_3_RAM_BAT       0x13
+#define MBC_4               0x15
+#define MBC_4_RAM           0x16
+#define MBC_4_RAM_BAT       0x17
+#define MBC_5               0x19
+#define MBC_5_RAM           0x1A
+#define MBC_5_RAM_BAT       0x1B
+#define MBC_5_RUM           0x1C
+#define MBC_5_RUM_RAM       0x1D
+#define MBC_5_RUM_RAM_BAT   0x1E
+#define MBC_POCKETCAM       0xFC
+#define MBC_BANDAITAMA5     0xFD
+#define MBC_HUC3            0xFE
+#define MBC_HUC1_RAM_BAT    0xFF
+
+#define ROM_32K     0x00
+#define ROM_64K     0x01
+#define ROM_128K    0x02
+#define ROM_256K    0x03
+#define ROM_512K    0x04
+#define ROM_1M      0x05
+#define ROM_2M      0x06
+#define ROM_4M      0x07
+#define ROM_1.1M    0x52
+#define ROM_1.2M    0x53
+#define ROM_1.5M    0x54
+
+#define RAM_NONE    0x00
+#define RAM_2K      0x01
+#define RAM_8K      0x02
+#define RAM_32K     0x03
+
+#endif

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -22,6 +22,7 @@ void Cartridge::loadCart(char* fname)
     }
 
     romLoaded = true;
+    getROMHeaderInfo();
 }
 
 void Cartridge::getROMHeaderInfo()
@@ -29,11 +30,17 @@ void Cartridge::getROMHeaderInfo()
     //Make sure our ROM is actually loaded first...
     if(romLoaded)
     {
-        m_MBCType = readRom(0x);
+        ROMHeaderInfo.MBCType = readRom(0x0147);
+        ROMHeaderInfo.ROMSize = readRom(0x0148);
+        ROMHeaderInfo.RAMSize = readRom(0x0149);
+        ROMHeaderInfo.region  = readRom(0x014A);
+        printf("MBC: 0x%x\nROM Size: 0x%x\nRAM Size: 0x%x\nRegion: 0x%x\n",
+            ROMHeaderInfo.MBCType, ROMHeaderInfo.ROMSize, ROMHeaderInfo.RAMSize,
+            ROMHeaderInfo.region);
     }
     else
     {
-        std::cerr << "Attempting to read header when ROM hasn't been loaded..."
+        std::cerr << "Attempting to read header when ROM hasn't been loaded...";
     }
 }
 

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -13,12 +13,24 @@ Cartridge::~Cartridge()
 //Load our cartridge into the ROM array
 void Cartridge::loadCart(char* fname)
 {
-    std::ifstream romfile(fname, std::ios::in | std::ios::binary);
+    std::ifstream romfile(fname, std::ios::in | std::ios::binary | std::ios::ate);
+    size_t filesize, bytesread;
 
     if(romfile.is_open())
     {
-        romfile.read((char*)rom0, sizeof(romfile));
+        filesize = romfile.tellg(); //Tells us the filesize in bytes.
+
+        rom0 = new uint8_t[filesize];
+        printf("ROM filesize: %i bytes.\n", filesize);
+        romfile.seekg(0, std::ios::beg);
+        romfile.read((char*)rom0, filesize);
+        bytesread = romfile.gcount();
+        printf("%i bytes read.\n", bytesread);
         romfile.close();
+    }
+    else {
+        printf("Error loading ROM file!\n");
+        return;
     }
 
     romLoaded = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ int main()
 {
     cpu.dumpCPU();
 
-    cart->loadCart("roms/tetris.gb");
+    cart->loadCart("roms/pokemonred.gb");
 
     std::cout << (uint16_t)cart->GameRom()[0x0001];
 }


### PR DESCRIPTION
Not really much to say. I saw your project and I'm interested in helping.

I've created a new header containing all of the definitions for each MBC type, ROM size and RAM size. Aside from that, I've moved the ROM header variable definitions into a struct to keep things more tidy. I've also modified Cartridge::getROMHeaderInfo() to load the relevant data about the ROM.

Hope this helps! Let me know if I can do anything else.
